### PR TITLE
feat: add getTrustLevelName

### DIFF
--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -342,3 +342,45 @@ describe('isSupportedArchitecture', () => {
     ).toBe(false);
   });
 });
+
+describe('getTrustLevelName', () => {
+  it('should return "stagedPublish" if stagedPublish is true', () => {
+    expect(
+      meta.getTrustLevelName({
+        provenance: false,
+        trustedPublisher: false,
+        stagedPublish: true,
+      }),
+    ).toBe('stagedPublish');
+  });
+
+  it('should return "trustedPublisher" if both trustedPublisher and provenance are true', () => {
+    expect(
+      meta.getTrustLevelName({
+        provenance: true,
+        trustedPublisher: true,
+        stagedPublish: false,
+      }),
+    ).toBe('trustedPublisher');
+  });
+
+  it('should return "provenance" if only provenance is true', () => {
+    expect(
+      meta.getTrustLevelName({
+        provenance: true,
+        trustedPublisher: false,
+        stagedPublish: false,
+      }),
+    ).toBe('provenance');
+  });
+
+  it('should return "none" if neither property is true', () => {
+    expect(
+      meta.getTrustLevelName({
+        provenance: false,
+        trustedPublisher: false,
+        stagedPublish: false,
+      }),
+    ).toBe('none');
+  });
+});

--- a/src/main.ts
+++ b/src/main.ts
@@ -54,6 +54,24 @@ export function getTrustLevel(status: TrustStatus): number {
   return 0;
 }
 
+export type TrustLevelName =
+  | 'none'
+  | 'provenance'
+  | 'trustedPublisher'
+  | 'stagedPublish';
+
+const trustLevelNames: Record<number, TrustLevelName> = {
+  0: 'none',
+  1: 'provenance',
+  2: 'trustedPublisher',
+  3: 'stagedPublish',
+};
+
+export function getTrustLevelName(status: TrustStatus): TrustLevelName {
+  const level = getTrustLevel(status);
+  return trustLevelNames[level] ?? 'none';
+}
+
 export function getTrustOrder(a: TrustStatus, b: TrustStatus): -1 | 0 | 1 {
   const levelA = getTrustLevel(a);
   const levelB = getTrustLevel(b);


### PR DESCRIPTION
This lets you get a human-readable scale name rather than using magic
numbers.
