### PR TITLE
fix: support staged publish through sniffing

### DIFF
--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -110,6 +110,53 @@ describe('getTrustStatus', () => {
       stagedPublish: false,
     });
   });
+
+  it('should set stagedPublish to true if the first key of meta is _id', () => {
+    expect(
+      meta.getTrustStatus({
+        _id: 'some-package@1.0.0',
+        otherKey: 'value',
+      }),
+    ).toEqual({
+      provenance: false,
+      trustedPublisher: false,
+      stagedPublish: true,
+    });
+  });
+
+  it('should set stagedPublish in addition to provenance', () => {
+    expect(
+      meta.getTrustStatus({
+        _id: 'some-package@1.0.0',
+        dist: {
+          attestations: {
+            url: 'https://example.com/provenance.json',
+            provenance: {
+              predicateType: 'https://slsa.dev/provenance/v1',
+            },
+          },
+        },
+      }),
+    ).toEqual({
+      provenance: true,
+      trustedPublisher: false,
+      stagedPublish: true,
+    });
+  });
+
+  it('should set stagedPublish to false when the first key of meta is not _id', () => {
+    expect(
+      meta.getTrustStatus({
+        name: 'some-package',
+        _id: 'some-package@1.0.0',
+        version: '1.0.0',
+      }),
+    ).toEqual({
+      provenance: false,
+      trustedPublisher: false,
+      stagedPublish: false,
+    });
+  });
 });
 
 describe('getTrustLevel', () => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -38,6 +38,14 @@ export function getTrustStatus(meta: unknown): TrustStatus {
   ) {
     status.provenance = true;
   }
+  // For now, we sniff the staging status out by the fact staged publishes
+  // always have _id as the first key and no other type of packument version
+  // does.
+  // TODO (jg): do this a less _true hacks_ way
+  const firstKey = Object.keys(meta)[0];
+  if (firstKey === '_id') {
+    status.stagedPublish = true;
+  }
   return status;
 }
 


### PR DESCRIPTION
Using the _kevin hack_, we can roughly guess the package is staged. This
will do until npm publish an official signal, and means we can unbreak
the various tools.
